### PR TITLE
Adding UPM Package Files to .NET Source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ artifacts/
 *_i.h
 *_p.h
 *.ilk
-*.meta
 *.obj
 *.pch
 *.pdb

--- a/source/dotnet/AdaptiveCards.NET.asmdef
+++ b/source/dotnet/AdaptiveCards.NET.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "AdaptiveCards.NET",
+    "rootNamespace": "",
+    "references": [
+    ],
+    "includePlatforms": [
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/source/dotnet/AdaptiveCards.NET.asmdef.meta
+++ b/source/dotnet/AdaptiveCards.NET.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eb73face4e67dc74c89ef2e9c539312d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/dotnet/package.json
+++ b/source/dotnet/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "com.microsoft.adaptivecards.net",
+  "version": "2.7.3",
+  "displayName": "Adaptive Cards",
+  "description": "For incorporating Adaptive Cards in Unity.",
+  "author": "Microsoft",
+  "license": "MIT",
+  "licensesUrl": "https://github.com/microsoft/AdaptiveCards/blob/main/LICENSE",
+  "unity": "2020.3",
+  "documentationUrl": "",
+  "changelogUrl": "",
+  "keywords": [
+	"AdaptiveCards"
+  ],
+  "dependencies": {
+	"com.unity.nuget.newtonsoft-json": "2.0.2"
+  }
+}

--- a/source/dotnet/package.json.meta
+++ b/source/dotnet/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 588306855a11fcd42a3ab63ca64afdba
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This should allow the .NET library be consumed as a UPM package from Unity.

